### PR TITLE
feat: add export/import save

### DIFF
--- a/index.html
+++ b/index.html
@@ -130,6 +130,8 @@
         <button id="newGameBtn">New Game</button>
         <button id="saveBtn">Save</button>
         <button id="loadBtn">Load</button>
+        <button id="exportBtn">Export</button>
+        <button id="importBtn">Import</button>
       </div>
       <!-- PANEL-CONTROLS:END -->
 
@@ -162,6 +164,8 @@
       const newBtn = document.getElementById('newGameBtn');
       const saveBtn = document.getElementById('saveBtn');
       const loadBtn = document.getElementById('loadBtn');
+      const exportBtn = document.getElementById('exportBtn');
+      const importBtn = document.getElementById('importBtn');
 
       const SAVE_KEY = 'barovia.save';
       const tiles = new Map();  // key: `q,r` => tile { q, r, x, y, el }
@@ -360,13 +364,39 @@
     // === REGION:SAVE:START ===
     function saveGame(silentArg){
       const silent = silentArg === true;
-      const data = { q: state.here.q, r: state.here.r, hp: state.hp, turn: state.turn, seed: state.seed };
+      const raw = serializeGame();
       try{
-        localStorage.setItem(SAVE_KEY, JSON.stringify(data));
+        localStorage.setItem(SAVE_KEY, raw);
         if(!silent) log('🗝️ Game saved.');
       }catch(e){
         log('⚠️ Save failed (storage blocked by browser).');
       }
+    }
+
+    function serializeGame(){
+      return JSON.stringify({ q: state.here.q, r: state.here.r, hp: state.hp, turn: state.turn, seed: state.seed });
+    }
+
+    function deserializeGame(raw){
+      let data;
+      try{
+        data = JSON.parse(raw);
+      }catch(e){
+        return null;
+      }
+      if(typeof data !== 'object' || typeof data.q !== 'number' || typeof data.r !== 'number' ||
+         typeof data.hp !== 'number' || typeof data.turn !== 'number' || typeof data.seed !== 'string'){
+        return null;
+      }
+      state.here = { q: data.q, r: data.r };
+      state.hp = data.hp;
+      state.turn = data.turn;
+      state.seed = data.seed;
+      placePlayer();
+      selectHere();
+      markAdjacents();
+      updateHUD();
+      return data;
     }
 
     function loadGame(){
@@ -381,27 +411,11 @@
         log('No save found.');
         return;
       }
-      let data;
-      try{
-        data = JSON.parse(raw);
-      }catch(e){
+      if(deserializeGame(raw)){
+        log(`✔ Loaded: (${state.here.q}, ${state.here.r}), HP ${state.hp}, Turn ${state.turn}.`);
+      }else{
         log('⚠️ Save is corrupted.');
-        return;
       }
-      if(typeof data !== 'object' || typeof data.q !== 'number' || typeof data.r !== 'number' ||
-         typeof data.hp !== 'number' || typeof data.turn !== 'number' || typeof data.seed !== 'string'){
-        log('⚠️ Save is corrupted.');
-        return;
-      }
-      state.here = { q: data.q, r: data.r };
-      state.hp = data.hp;
-      state.turn = data.turn;
-      state.seed = data.seed;
-      placePlayer();
-      selectHere();
-      markAdjacents();
-      updateHUD();
-      log(`✔ Loaded: (${state.here.q}, ${state.here.r}), HP ${state.hp}, Turn ${state.turn}.`);
     }
     // === REGION:SAVE:END ===
 
@@ -409,12 +423,34 @@
     newBtn.addEventListener('click', newGame);
     saveBtn.addEventListener('click', saveGame);
     loadBtn.addEventListener('click', loadGame);
+    exportBtn.addEventListener('click', exportGame);
+    importBtn.addEventListener('click', importGame);
     // === REGION:INPUT:END ===
 
     // === REGION:SETTINGS:START ===
     // === REGION:SETTINGS:END ===
 
     // === REGION:FEATURES:START ===
+    async function exportGame(){
+      const raw = serializeGame();
+      try{
+        await navigator.clipboard.writeText(raw);
+        log('📋 Save copied to clipboard.');
+      }catch(e){
+        log('⚠️ Clipboard unavailable.');
+      }
+    }
+
+    function importGame(){
+      const raw = prompt('Paste save JSON');
+      if(!raw) return;
+      if(deserializeGame(raw)){
+        saveGame(true);
+        log(`✔ Imported: (${state.here.q}, ${state.here.r}), HP ${state.hp}, Turn ${state.turn}.`);
+      }else{
+        log('⚠️ Invalid save.');
+      }
+    }
     // === REGION:FEATURES:END ===
 
     init();


### PR DESCRIPTION
## Summary
- add Export and Import buttons
- enable save serialization and clipboard export
- allow loading state from pasted JSON with validation

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a12075107c832b91c9fcc9afb7ea2b