### PR TITLE
feat: add log clear and copy controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -86,7 +86,10 @@
       overflow: auto; font-size: 14px; line-height: 1.35; color: var(--ink);
       scrollbar-width: thin; scrollbar-color: var(--accent-dim) transparent;
     }
-    #log h2 { margin: 0 0 6px 0; font-size: 14px; font-variant: small-caps; letter-spacing:.8px; color: var(--ink-dim); }
+    #log h2 { margin: 0 0 6px 0; font-size: 14px; font-variant: small-caps; letter-spacing:.8px; color: var(--ink-dim); display:flex; align-items:center; gap:6px; }
+    #log h2 button { background: none; border: none; color: var(--ink-dim); font-family: inherit; font-size: 12px; cursor: pointer; }
+    #log h2 button:hover { color: var(--ink); }
+    #copyMsg { font-size: 12px; color: var(--ink-dim); }
     #logList { list-style: none; margin: 0; padding: 0; }
     #logList li { padding: 6px 8px; margin: 0 0 6px 0; background: rgba(0,0,0,.22); border-radius: 8px; border: 1px solid rgba(255,255,255,.03); }
 
@@ -135,7 +138,12 @@
 
       <!-- PANEL-LOG:START -->
       <div id="log" class="panel" aria-live="polite">
-        <h2>Journal</h2>
+        <h2>
+          Journal
+          <button id="clearLogBtn">Clear</button>
+          <button id="copyLogBtn">Copy</button>
+          <span id="copyMsg" aria-live="polite"></span>
+        </h2>
         <ul id="logList"></ul>
       </div>
       <!-- PANEL-LOG:END -->
@@ -162,6 +170,9 @@
       const newBtn = document.getElementById('newGameBtn');
       const saveBtn = document.getElementById('saveBtn');
       const loadBtn = document.getElementById('loadBtn');
+      const clearLogBtn = document.getElementById('clearLogBtn');
+      const copyLogBtn = document.getElementById('copyLogBtn');
+      const copyMsg = document.getElementById('copyMsg');
 
       const SAVE_KEY = 'barovia.save';
       const tiles = new Map();  // key: `q,r` => tile { q, r, x, y, el }
@@ -255,6 +266,21 @@
       // scroll to bottom
       const logPanel = document.getElementById('log');
       logPanel.scrollTop = logPanel.scrollHeight;
+    }
+
+    function clearLog(){
+      logList.innerHTML = '';
+    }
+
+    async function copyLog(){
+      const text = Array.from(logList.children).map(li => li.textContent).join('\n');
+      try{
+        await navigator.clipboard.writeText(text);
+        copyMsg.textContent = 'Copied';
+      }catch(e){
+        copyMsg.textContent = 'Copy failed';
+      }
+      setTimeout(()=>{ copyMsg.textContent = ''; }, 1000);
     }
 
     function selectHere(){
@@ -409,6 +435,8 @@
     newBtn.addEventListener('click', newGame);
     saveBtn.addEventListener('click', saveGame);
     loadBtn.addEventListener('click', loadGame);
+    clearLogBtn.addEventListener('click', clearLog);
+    copyLogBtn.addEventListener('click', copyLog);
     // === REGION:INPUT:END ===
 
     // === REGION:SETTINGS:START ===


### PR DESCRIPTION
## Summary
- add clear and copy buttons to the log panel
- implement helpers to wipe or copy log entries with clipboard feedback

## Testing
- `npm test` *(fails: enoent Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a12067d600832b90ed1c11df69b897